### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,6 +17,8 @@ defaults:
 jobs:
   pre-commit-job-identifier:
     name: pre-commit job name
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: checkout commit step


### PR DESCRIPTION
Potential fix for [https://github.com/yarnabrina/learn-model-context-protocol/security/code-scanning/1](https://github.com/yarnabrina/learn-model-context-protocol/security/code-scanning/1)

To address the issue, we should add a `permissions` block to the `pre-commit-job-identifier` job in `.github/workflows/code-quality.yml`. This block should be placed at the same indentation level as `runs-on`, `name`, and `steps`. For this job, the minimum required permission is most likely `contents: read`, since the steps only check out code and run Python scripts locally. Insert the following under line 19:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or code edits are required outside this YAML change. No existing functionality or behavior will be altered.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
